### PR TITLE
Fix syntax: multiple languages

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2015 Oliver Pattison
+Copyright (c) 2016 Oliver Pattison
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "newbound-light-syntax",
   "theme": "syntax",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A legible, moderately high contrast, light syntax theme for Atom",
   "keywords": [
     "syntax",

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -67,6 +67,7 @@ atom-text-editor, :host {
   .bracket-matcher .region {
     border-bottom: 2px solid @base0D;
     box-sizing: border-box;
+    background-color: fadeout(@base0D, 92%);
   }
 
   .search-results .marker .region {

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -61,7 +61,7 @@ atom-text-editor, :host {
 
   .line-number.cursor-line-no-selection,
   .line.cursor-line {
-    background-color: mix(@base0D, @base07, 10%);
+    background-color: fadeout(@base0D, 92%); // not too bright to be confused with base07
   }
 
   .bracket-matcher .region {

--- a/styles/language.less
+++ b/styles/language.less
@@ -116,7 +116,7 @@
 
 .support {
   &.class {
-    color: @base09;
+    color: @base0A;
   }
 
   &.function  {

--- a/styles/language.less
+++ b/styles/language.less
@@ -8,7 +8,7 @@
   color: @base0D;
 
   &.control {
-    color: @base0D;
+    color: @base0E;
   }
 
   &.operator {

--- a/styles/languages/css.less
+++ b/styles/languages/css.less
@@ -43,7 +43,7 @@
     }
 
     &.other.less {
-      color: @base08;
+      color: @base08; // syntax handled differently between less and scss
     }
   }
 

--- a/styles/languages/gfm.less
+++ b/styles/languages/gfm.less
@@ -24,7 +24,6 @@
   }
 
   .link {
-
     .punctuation.definition {
       color: @base04;
     }

--- a/styles/languages/javascript.less
+++ b/styles/languages/javascript.less
@@ -1,4 +1,8 @@
 .source.js {
+  .punctuation {
+    color: @base02;
+  }
+
   .keyword.operator {
     color: @base01;
 
@@ -15,5 +19,25 @@
     &.comparison {
       color: @base0E;
     }
+  }
+
+  .function {
+    &.parameter {
+      color: @base01;
+    }
+  }
+
+  .meta {
+    &.brace {
+      color: @base02;
+    }
+
+    &.arguments {
+      color: @base01;
+    }
+  }
+
+  .comment {
+    color: @base03;
   }
 }

--- a/styles/languages/json.less
+++ b/styles/languages/json.less
@@ -1,5 +1,5 @@
 .source.json {
-  .meta.structure.dictionary {
+  .dictionary {
     .string.quoted {
       color: @base0D;
     }
@@ -10,19 +10,17 @@
     }
   }
 
-  .meta.structure.array {
+  .array {
     .string.quoted {
       color: @base0B;
     }
   }
 
-  .meta.structure {
-    .punctuation {
-      color: @base02;
+  .punctuation {
+    color: @base02;
 
-      &.key-value {
-        color: @base01;
-      }
+    &.key-value {
+      color: @base01;
     }
   }
 }

--- a/styles/languages/ruby.less
+++ b/styles/languages/ruby.less
@@ -1,5 +1,4 @@
 .source.ruby {
-
   .constant {
     &.boolean {
       color: @base0A;
@@ -7,7 +6,6 @@
   }
 
   .keyword {
-
     &.operator {
       color: @base01;
 
@@ -20,5 +18,4 @@
       }
     }
   }
-
 }

--- a/styles/languages/ruby.less
+++ b/styles/languages/ruby.less
@@ -6,12 +6,6 @@
     }
   }
 
-  .entity {
-    &.function {
-      color: @base0E;
-    }
-  }
-
   .keyword {
 
     &.operator {


### PR DESCRIPTION
- Use transparent value (instead of mixed value) for selected line
- Clearer bracket matching
- More consistent (subtler) JavaScript punctuation
- Change class default
- More consistency with Ruby/general `.control`/`.function` colors
- De-specify JSON selectors
